### PR TITLE
Add kripod/uuidv7

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Draft Prototypes and Tests for UUIDv6 and beyond
 | [bradleypeabody/gouuidv6](https://github.com/bradleypeabody/gouuidv6)                       | GO         | Yes    | No     | No     | [0x](http://gh.peabody.io/uuidv6/)                                          |
 | [sprql/uuid7-ruby](https://github.com/sprql/uuid7-ruby)                                     | Ruby       | No     | Yes    | No     | [01](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-01) |
 | [kjmph/UUID_v7_for_Postgres.sql](https://gist.github.com/kjmph/5bd772b2c2df145aa645b837da7eca74) | Postgres       | No     | Yes    | No     | [01](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-01) |
-| [kripod/uuidv7](https://github.com/kripod/uuidv7)                                           | TypeScript | No     | Yes    | No     | [01](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-01) |
+| [kripod/uuidv7](https://github.com/kripod/uuidv7)                                           | TypeScript | No     | Yes    | No     | [02](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-02) |
 
 *Note: UUIDv8 prototypes will likely vary among implementations*
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Draft Prototypes and Tests for UUIDv6 and beyond
 | [bradleypeabody/gouuidv6](https://github.com/bradleypeabody/gouuidv6)                       | GO         | Yes    | No     | No     | [0x](http://gh.peabody.io/uuidv6/)                                          |
 | [sprql/uuid7-ruby](https://github.com/sprql/uuid7-ruby)                                     | Ruby       | No     | Yes    | No     | [01](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-01) |
 | [kjmph/UUID_v7_for_Postgres.sql](https://gist.github.com/kjmph/5bd772b2c2df145aa645b837da7eca74) | Postgres       | No     | Yes    | No     | [01](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-01) |
+| [kripod/uuidv7](https://github.com/kripod/uuidv7)                                           | TypeScript | No     | Yes    | No     | [01](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-01) |
 
 *Note: UUIDv8 prototypes will likely vary among implementations*
 


### PR DESCRIPTION
See: https://github.com/kripod/uuidv7 – an isomorhpic TypeScript implementation of UUIDv7, based on RFC4122 [v02](https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-02)