### PR TITLE
Fix reference to uuid8 into the uuid7 prototypes.

### DIFF
--- a/python/new_uuid.py
+++ b/python/new_uuid.py
@@ -262,7 +262,7 @@ def uuid7(devDebugs=False, returnType="hex"):
         if UUIDv7_int < _last_uuid_int and _last_uuid_int != 0:
             print("Error: UUID went Backwards!")
             print("UUIDv7 Last: " + str(_last_uuid_int))
-            print("UUIDv7 Curr: " + str(UUIDv8_int))
+            print("UUIDv7 Curr: " + str(UUIDv7_int))
     _last_uuid_int = UUIDv7_int
 
     # Convert Hex to Int then splice in dashes


### PR DESCRIPTION
Looking at the different prototypes of the new uuid standard and I've realized we were referring to a uuid8 variable into the uuid7 one. This PR is fixing this.