### PR TITLE
Add implementation in posix shell: uuid.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Draft Prototypes and Tests for UUIDv6 and beyond
 | [karwa/uniqueid](https://github.com/karwa/uniqueid)                                         | Swift      | Yes    | No     | No     | [02](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-02) |
 | [mareek/UUIDNext](https://github.com/mareek/UUIDNext)                                       | C#         | Yes    | Yes    | No     | [02](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-02) |
 | [oittaa/uuid-php](https://github.com/oittaa/uuid-php)                                       | PHP      | Yes    | Yes     | No     | [02](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-02) |
+| [jakwings/uuid.sh](https://github.com/jakwings/uuid.sh)                                     | Shell      | Yes    | Yes    | Yes    | [02](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-02) |
 
 *Note: UUIDv8 prototypes will likely vary among implementations*
 


### PR DESCRIPTION
```
uuid.sh -- a UUID Generator in POSIX Shell

Usage:
    uuid [<options>] [<version> [<arguments>]]
        Generate a Universally Unique Identifier.
        The default version to use is "v4".

Options:
    -h, --help
        Show this help information.
    -b, --binary
        Output bytes in binary instead of plain-text format.
    -d, --decode
        Extract data from UUIDs generated by this program.
    -g, --guid
        Output variant-2 UUIDs by costing 1 bit of randomness.
    -n, --next
        Output the next UUID for version 1, 2, 6, or 7.
    -s, --seed <number>
        Use a deterministic pseudo-random number generator.
    -l, --lowercase
        Use lower-case letters for UUID output in plain text.
    -u, --uppercase
        Use upper-case letters for UUID output in plain text.

Summary of available versions:
    uuid v0 <uuid>
        ... Output key=value pairs for sourcing when -d flag is on ...
    uuid v1 [<period> [<sequence> [<node>]]]
        ... Gregorian timestamp plus privacy and security concerns ...
    uuid v2 [<domain> <identifier> [<period> [<sequence> [<node>]]]]
        ... v1 of less available IDs per clock tick but DCE Security ...
    uuid v3 <uuid> <text>...
        ... 16 bytes of 6 fixed bits from a 16-byte MD5 hash ...
    uuid v4 [<count>]
        ... 16 (pseudo-)random bytes of 6 predetermined bits ...
    uuid v5 <uuid> <text>...
        ... 16 bytes of 6 fixed bits from a 20-byte SHA-1 hash ...
    uuid v6 [<period> [<sequence> [<node>]]]
        ... Draft#2: lexicographically sortable by Gregorian timestamp ...
    uuid v7 [<second> [<subsecond> [<sequence> [<node>]]]]
        ... Draft#2: lexicographically sortable by Unix Epoch timestamp ...
    uuid v8 [<year> [<month> [<day> [<hour> [<minute> [<node>]]]]]]
        ... Draft#2: lexicographically sortable by custom timestamp ...

Notes:
    For time-based UUIDs, users must provide a system-wide global lock
    to avoid race conditions among generators runing at the same time.
    Please reference section 4.2 of RFC4122 for useful tips.
    https://www.rfc-editor.org/rfc/inline-errata/rfc4122.html
```
