### PR TITLE
Dart library updated to Draft 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Draft Prototypes and Tests for UUIDv6 and beyond
 | [uuid6/prototypes/python](https://github.com/uuid6/prototypes/tree/main/python)             | Python     | Yes    | Yes    | Yes    | [02](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-02) |
 | [oittaa/uuid6-python](https://github.com/oittaa/uuid6-python)             | Python     | Yes    | Yes    | No    | [03](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-03) |
 | [jdknezek/uuid6-zig](https://github.com/jdknezek/uuid6-zig)                                 | Zig        | Yes    | Yes    | No     | [03](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-03) |
-| [daegalus/uuid/tree/uuid6](https://github.com/Daegalus/dart-uuid/tree/uuidv6)               | Dart       | Yes    | Yes    | No     | [01](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-01) |
+| [daegalus/uuid/tree/uuid6](https://github.com/Daegalus/dart-uuid/tree/uuidv6)               | Dart       | Yes    | Yes    | Yes    | [03](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-03) |
 | [f4b6a3/uuid-creator](https://github.com/f4b6a3/uuid-creator)                               | Java       | Yes    | No     | No     | [01](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-01) |
 | [chrylis/time-based-uuid-reordering](https://github.com/chrylis/time-based-uuid-reordering) | Java       | Yes    | No     | No     | [01](https://tools.ietf.org/html/draft-peabody-dispatch-new-uuid-format-01) |
 | [mikemix/php-uuid-v6](https://github.com/mikemix/php-uuid-v6)                               | PHP        | Yes    | No     | No     | [0x](http://gh.peabody.io/uuidv6/)                                          |


### PR DESCRIPTION
I have updated my UUIDv6 branch to Draft 3. 

I have updated my UUIDv7 implementation, and added a custom UUIDv8 implementation inspired by `uuid.sh`'s v8 implementation.

Until we get some more test vectors, I feel it works fairly well.